### PR TITLE
removed globalstrict as it is deprecated

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -40,7 +40,6 @@
     "evil" : false,
     "expr" : true,     // true: Tolerate `ExpressionStatement` as Programs
     "funcscope" : false,
-    "globalstrict" : false,
     "iterator" : false,
     "lastsemic" : false,
     "laxbreak" : false,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // Copyright 2015, EMC, Inc.
-/* jshint: node:true */
 
 'use strict';
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,5 +1,4 @@
 // Copyright 2015, EMC, Inc.
-/* jshint: node:true */
 
 'use strict';
 


### PR DESCRIPTION
When this is left in it causes jshint warnings when trying to override jshint for a certain file.

Also /* jshint: node:true */ is not valid. It needs to be /* jshint node:true */ to be valid. Node:true is in the .jshintrc so it is not needed. 
