### PR TITLE
rationalizing logs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -19,13 +19,14 @@ di.annotate(syslogServiceFactory, new di.Inject(
 function syslogServiceFactory(core, configuration, Logger, Promise, _, dgram)  {
     var logger = Logger.initialize(syslogServiceFactory);
     var server = dgram.createSocket('udp4');
-    var levels = [
-        'emerg',
-        'alert',
-        'crit',
+    // for mapping external syslog message levels to internal
+    var syslogLevels = [
+        'critical', //syslog.emerg
+        'critical', //syslog.alert
+        'critical', //syslog.crit
         'error',
         'warning',
-        'notice',
+        'info', //syslog.notice
         'info',
         'debug'
     ];
@@ -53,7 +54,7 @@ function syslogServiceFactory(core, configuration, Logger, Promise, _, dgram)  {
                             facility = Math.floor(prival / 8),
                             priority = prival - (facility * 8);
 
-                        level = levels[priority];
+                        level = syslogLevels[priority];
                         message = match[2].trim();
 
                         meta.facility = facility;
@@ -68,11 +69,11 @@ function syslogServiceFactory(core, configuration, Logger, Promise, _, dgram)  {
             });
 
             server.on('listening', function () {
-                logger.notice('Listening');
+                logger.info('Syslog service is listening');
             });
 
             server.on('error', function (error) {
-                logger.error('SysLog Service Error.', {
+                logger.error('SysLog service error.', {
                     error: error
                 });
             });
@@ -81,7 +82,7 @@ function syslogServiceFactory(core, configuration, Logger, Promise, _, dgram)  {
                 // Don't use logger here, because in stop() we close the server
                 // and close the message bus, so the logger will try to log on
                 // the now closed bus.
-                console.log('Syslog server closed');
+                console.info('Syslog server closed');
             });
 
             server.bind(

--- a/spec/lib/app-spec.js
+++ b/spec/lib/app-spec.js
@@ -143,7 +143,7 @@ describe(require('path').basename(__filename), function () {
                 return startedSyslogServer.then(function() {
                     fakeserver.emit('message', fakeData, {});
                 }).then(function() {
-                    expect(loggerSpy.firstCall.args[0]).to.equal('emerg');
+                    expect(loggerSpy.firstCall.args[0]).to.equal('critical');
                 });
             });
             it('tagged with <1> is alert', function() {
@@ -151,7 +151,7 @@ describe(require('path').basename(__filename), function () {
                 return startedSyslogServer.then(function() {
                     fakeserver.emit('message', fakeData, {});
                 }).then(function() {
-                    expect(loggerSpy.firstCall.args[0]).to.equal('alert');
+                    expect(loggerSpy.firstCall.args[0]).to.equal('critical');
                 });
             });
             it('tagged with <2> is crit', function() {
@@ -159,7 +159,7 @@ describe(require('path').basename(__filename), function () {
                 return startedSyslogServer.then(function() {
                     fakeserver.emit('message', fakeData, {});
                 }).then(function() {
-                    expect(loggerSpy.firstCall.args[0]).to.equal('crit');
+                    expect(loggerSpy.firstCall.args[0]).to.equal('critical');
                 });
             });
             it('tagged with <3> is error', function() {
@@ -183,7 +183,7 @@ describe(require('path').basename(__filename), function () {
                 return startedSyslogServer.then(function() {
                     fakeserver.emit('message', fakeData, {});
                 }).then(function() {
-                    expect(loggerSpy.firstCall.args[0]).to.equal('notice');
+                    expect(loggerSpy.firstCall.args[0]).to.equal('info');
                 });
             });
             it('tagged with <6> is info', function() {


### PR DESCRIPTION
updating mapping to more constricted set of logs per
https://github.com/RackHD/RackHD/issues/34

**NOTE**: Requires https://github.com/RackHD/on-core/pull/48 to be
committed prior to tests passing, as it adds the synonym 'critical' to
the existing 'crit' level.