### PR TITLE
Remove entrypoint from Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.bintray.json
+.dockerignore
+.git
+.gitignore
+.hound.yml
+.jshintrc
+.travis.yml
+Dockerfile
+Gruntfile.js
+HWIMO-*
+LICENSE
+README.md
+spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,4 @@ RUN cp -a /tmp/node_modules /RackHD/on-syslog/
 EXPOSE 514
 EXPOSE 514/udp
 
-ENTRYPOINT [ "node" ]
-CMD [ "/RackHD/on-syslog/index.js" ]
+CMD [ "node", "/RackHD/on-syslog/index.js" ]


### PR DESCRIPTION
This makes it easier to debug docker images and containers.