### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,9 +5,11 @@
 .hound.yml
 .jshintrc
 .travis.yml
+debian/
 Dockerfile
 Gruntfile.js
 HWIMO-*
 LICENSE
+node_modules/
 README.md
 spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,13 @@
 
 FROM rackhd/on-core
 
-RUN mkdir -p /RackHD/on-syslog
+COPY . /RackHD/on-syslog/
 WORKDIR /RackHD/on-syslog
 
-COPY ./package.json /tmp/
-RUN cd /tmp \
-  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
+RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-core ./node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production
 
-COPY . /RackHD/on-syslog/
-RUN cp -a -f /tmp/node_modules /RackHD/on-syslog/
-
 EXPOSE 514/udp
-
 CMD [ "node", "/RackHD/on-syslog/index.js" ]


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.
